### PR TITLE
fix the problem that elb couldn't connect to tidb

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -385,6 +385,7 @@ module "elb_internal_tidb" {
   depends_on = [
     module.ec2_internal_tidb
   ]
+  number_of_instances = var.tidb_count
   instances = module.ec2_internal_tidb.*.id
 }
 


### PR DESCRIPTION
With original main.tf, elb couldn't connect tidb because there is no target to the instances.
It needs to specify the number_of_instances variable. 

This script was tested and checked that it created connections to the tidb instances.