### PR TITLE
add version for alb-module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -391,6 +391,7 @@ module "ec2_internal_monitor" {
 // Load Balancer (NLB) (backend: internal tidb ec2 instances)
 module "nlb_internal_tidb" {
   source              = "terraform-aws-modules/alb/aws"
+  version             = "8.7.0"
   name                = "${var.name_prefix}-internal-nlb-tidb"
   load_balancer_type  = "network"
   vpc_id              = module.vpc.vpc_id


### PR DESCRIPTION
add version for aws-alb-modle.

Note: >v9.x has a breaking change, which makes it hard to use multiple IPs for the target group. I decided not to use this version at the moment.